### PR TITLE
Add pip package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+0.0.1
+
+- Flexible Configuration:
+  - Supports various authentication methods including client_secret_basic and private_key_jwt.
+  - Configurable token endpoint auth method.
+  - Configurable JWKS for signing and encryption.
+- Authorization:
+  - Generation of authorization URL with support for different scopes, and parameters like scope and claims.
+  - Support for both standard and pushed authorization requests.
+  - Generation of proofs including state, nonce, and code verifier for PKCE.
+- Token Acquisition:
+  - Token exchange functionality for obtaining tokens from an authorization code.
+- User Information Retrieval:
+  - Userinfo endpoint interaction to retrieve user information using an access token.
+- JWT Handling:
+  - JWT decoding support including handling of encrypted JWTs.
+  - JWT signing and encryption support.
+- Utilities:
+  - Fetching provider configuration from the well-known configuration endpoint.
+- Error Handling:
+  - Comprehensive error handling for various steps in the OIDC interaction process.
+- Example:
+  - Sinatra example usage provided in the examples folder demonstrating how to use the IDPartner class for OIDC interactions.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2023 IDPartner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# python_oidc_client
+
+python_oidc_client is a Python package that simplifies OpenID Connect (OIDC) client operations within Flask applications. This package provides functionalities to interact with OIDC providers, making authentication and authorization processes easier.
+
+## Installation
+
+You can install the python_oidc_client package using pip:
+
+```bash
+pip install python_oidc_client
+```
+
+## Usage
+
+Please check the [examples folder](./examples/)
+
+### Running Tests
+
+To run tests, install the required dependencies and execute:
+
+```bash
+pytest
+```
+
+## Running Flake8
+
+To check the code for style compliance using Flake8, run:
+
+```bash
+flake8
+```
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at [https://github.com/idpartner-app/python_oidc_client](https://github.com/idpartner-app/python_oidc_client).
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# IDPartner examples
+
+This contains the an example with the [python_oidc_client](https://github.com/idpartner-app/python_oidc_client) library, called [client-secret-basic](./client-secret-basic/README.md), which is a flask project using the client_secret_basic authentication method to obtain user info

--- a/examples/client_secret_basic/README.md
+++ b/examples/client_secret_basic/README.md
@@ -1,0 +1,24 @@
+# client_secret_basic flow using python_oidc_client lib
+
+## Prerequisites
+
+1. [Create an IDPartner Account](https://console.idpartner.com).
+1. [Create an Application (Client Secret)](https://docs.idpartner.com/documentation/relying-party-user-guide/registering-your-app#create-an-application).
+1. Ensure the following properties are set:
+   - Origin URL: http://localhost:3001/button/oauth
+   - Redirect URL: http://localhost:3001/button/oauth/callback
+1. Grab the "Client ID" and the "Client Secret" to update the following parts in your code:
+   1. [Update CHANGE_ME_CLIENT_ID in the configuration file](./config.json)
+   1. [Update CHANGE_ME_CLIENT_SECRET in the configuration file](./config.json)
+
+   Aditionally you optionally can configure the next steps:
+   1. [Update the "redirect_uri" in the configuration file](./config.json)
+
+## Running the project
+
+1. Run: `pip install python_oidc_client flask`
+1. Run: `flask  run -p 3001 --debug`
+1. Access http://localhost:3001
+1. Click the "Choose your ID Partner" button
+1. Search for "Mikomo Bank"
+1. Use these test credentials `mikomo_10/mikomo_10`

--- a/examples/client_secret_basic/app.py
+++ b/examples/client_secret_basic/app.py
@@ -1,0 +1,53 @@
+from idpartner import IDPartner
+from authlib.integrations.flask_client import OAuth
+from flask import Flask, render_template, request, redirect, session, jsonify
+import json
+
+with open("config.json", "r") as config_file:
+    config = json.load(config_file)
+
+app = Flask(__name__)
+app.secret_key = config.get("cookie_secret")
+
+oauth = OAuth(app)
+id_partner = IDPartner(
+    oauth,
+    {
+        "client_id": config.get("client_id"),
+        "client_secret": config.get("client_secret"),
+        "account_selector_service_url": "http://localhost:9002",
+        "redirect_uri": config.get("redirect_uri"),
+    },
+)
+
+
+@app.route("/")
+def index():
+    title = "RP Client Secret Example"
+    return render_template("index.html", title=title, config=config)
+
+
+@app.route("/jwks")
+def jwks():
+    return jsonify(id_partner.jwks())
+
+
+@app.route("/button/oauth")
+def oauth():
+    scope = config["scope"]
+    proofs = id_partner.generate_proofs()
+    session["proofs"] = proofs
+    query_params = request.args.to_dict()
+    return redirect(id_partner.get_authorization_url(query_params, proofs, scope))
+
+
+@app.route("/button/oauth/callback")
+def oauth_callback():
+    query_params = request.args.to_dict()
+    token = id_partner.token(query_params, session.get("proofs"))
+    userinfo = id_partner.userinfo(token)
+    return jsonify(userinfo)
+
+
+if __name__ == "__main__":
+    app.run(port=config.get("port"), debug=True)

--- a/examples/client_secret_basic/config.json
+++ b/examples/client_secret_basic/config.json
@@ -1,0 +1,8 @@
+{
+  "client_id": "F8W8ZKUiyRX_0noOLa943",
+  "client_secret": "edhQyIjEg1HV9sNy2W4U-c6TVRQLsYTq2z8P6eg8X8a6eSr6HJaz943foNADNLipCFpO-zb8minhBDyIlDVbTw",
+  "redirect_uri": "http://localhost:3001/button/oauth/callback",
+  "scope": "openid offline_access email profile birthdate address",
+  "cookie_secret": "CHANGE_ME_COOKIE_SECRET",
+  "port": 3001
+}

--- a/examples/client_secret_basic/static/style.css
+++ b/examples/client_secret_basic/static/style.css
@@ -1,0 +1,8 @@
+body {
+  padding: 50px;
+  font: 14px "Lucida Grande", Helvetica, Arial, sans-serif;
+}
+
+a {
+  color: #00B7FF;
+}

--- a/examples/client_secret_basic/templates/index.html
+++ b/examples/client_secret_basic/templates/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- <script src="https://install.idpartner.com/script.js"></script> -->
+    <script src="http://localhost:4004/button.js"></script>
+    <title>{{ title }}</title>
+    <link rel='stylesheet' href='{{ url_for("static", filename="style.css") }}' />
+  </head>
+  <body>
+    <id-partner id="{{ config.get('client_id') }}"></id-partner>
+  </body>
+</html>

--- a/examples/client_secret_basic/templates/index.html
+++ b/examples/client_secret_basic/templates/index.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <!-- <script src="https://install.idpartner.com/script.js"></script> -->
-    <script src="http://localhost:4004/button.js"></script>
+    <script src="https://install.idpartner.com/script.js"></script>
     <title>{{ title }}</title>
     <link rel='stylesheet' href='{{ url_for("static", filename="style.css") }}' />
   </head>

--- a/idpartner/__init__.py
+++ b/idpartner/__init__.py
@@ -1,0 +1,234 @@
+from authlib.common.security import generate_token
+import urllib.parse
+import json
+import uuid
+import os
+import secrets
+import hashlib
+import base64
+import requests
+from authlib.oauth2.rfc7636 import create_s256_code_challenge
+import authlib.jose as jose
+from datetime import datetime, timedelta
+
+
+class IDPartner:
+    SUPPORTED_AUTH_METHODS = [
+        "client_secret_basic",
+        "tls_client_auth",
+        "private_key_jwt",  # For backward compatibility
+    ]
+    SIGNING_ALG = "PS256"
+    ENCRYPTION_ALG = "RSA-OAEP"
+    ENCRYPTION_ENC = "A256CBC-HS512"
+
+    def __init__(self, oauth, config):
+        if not oauth:
+            raise ValueError("OAuth missing.")
+        if not config:
+            raise ValueError("Config missing.")
+
+        default_config = {
+            "account_selector_service_url": "https://auth-api.idpartner.com/oidc-proxy",
+            "token_endpoint_auth_method": "client_secret_basic",
+            "jwks": None,
+            "client_secret": None,
+        }
+
+        self.config = {**default_config, **config}
+
+        if (
+            self.config.get("token_endpoint_auth_method")
+            not in self.SUPPORTED_AUTH_METHODS
+        ):
+            raise ValueError(
+                f"Unsupported token_endpoint_auth_method '{self.config.get('token_endpoint_auth_method')}'. "
+                f"It must be one of ({', '.join(self.SUPPORTED_AUTH_METHODS)})"
+            )
+
+        client_secret_config = (
+            {"client_secret": self.config["client_secret"]}
+            if self.config.get("token_endpoint_auth_method") == "client_secret_basic"
+            else {}
+        )
+
+        jwks_config = (
+            {
+                "authorization_encrypted_response_alg": self.ENCRYPTION_ALG,
+                "authorization_encrypted_response_enc": self.ENCRYPTION_ENC,
+                "id_token_encrypted_response_alg": self.ENCRYPTION_ALG,
+                "id_token_encrypted_response_enc": self.ENCRYPTION_ENC,
+                "request_object_signing_alg": self.SIGNING_ALG,
+            }
+            if self.config.get("jwks")
+            else {}
+        )
+
+        self.config = {
+            **self.config,
+            **{
+                "authorization_signed_response_alg": self.SIGNING_ALG,
+                "id_token_signed_response_alg": self.SIGNING_ALG,
+            },
+            **client_secret_config,
+            **jwks_config,
+        }
+        if self.config.get("jwks"):
+            self.config["jwks"] = jose.JsonWebKey.import_key_set(self.config["jwks"])
+        self.oauth = oauth
+
+    def generate_proofs(self):
+        return {
+            "state": generate_token(43),
+            "nonce": generate_token(43),
+            "code_verifier": generate_token(43),
+        }
+
+    def jwks(self):
+        if not self.config.get("jwks"):
+            return {}
+        public_jwks = []
+        for jwk in self.config.get("jwks").keys:
+            public_jwk = jwk.as_dict()
+            public_jwk.update({
+                "alg": jwk["alg"],
+                "use": jwk["use"]
+            })
+            public_jwks.append(public_jwk)
+
+        return {"keys": public_jwks}
+
+    def get_authorization_url(
+        self, query, proofs, scope, extra_authorization_params={}
+    ):
+        if "iss" not in query:
+            return f"{self.config.get('account_selector_service_url')}/auth/select-accounts?client_id={self.config.get('client_id')}&visitor_id={query.get('visitor_id')}&scope={scope}&claims={'+'.join(self._extract_claims(extra_authorization_params.get('claims', [])))}"
+
+        self.config["iss"] = query.get("iss")
+        self._init_client(query.get("iss"))
+
+        extra_authorization_params["claims"] = json.dumps(
+            extra_authorization_params.get("claims")
+        )
+        extended_authorization_params = {
+            "redirect_uri": self.config.get("redirect_uri"),
+            "code_challenge_method": "S256",
+            "code_challenge": create_s256_code_challenge(proofs.get("code_verifier")),
+            "state": proofs.get("state"),
+            "nonce": proofs.get("nonce"),
+            "scope": scope,
+            "response_type": "code",
+            "client_id": self.config.get("client_id"),
+            "x-fapi-interaction-id": str(uuid.uuid4()),
+            "identity_provider_id": query.get("idp_id"),
+            "idpartner_token": query.get("idpartner_token"),
+            "response_mode": "jwt",
+        }
+
+        pushed_authorization_request_params = extended_authorization_params
+        if self.config.get("jwks"):
+            pushed_authorization_request_params = {
+                "request": self._create_request_object(extended_authorization_params)
+            }
+
+        request_uri = self._push_authorization_request(
+            pushed_authorization_request_params
+        ).get("request_uri")
+        return (
+            self.oauth_client.server_metadata.get("authorization_endpoint")
+            + f"?request_uri={request_uri}"
+        )
+
+    def token(self, query, proofs):
+        jwt = query.get("response")
+
+        code = self._decode_jwt(jwt).get("code")
+        return self.oauth_client.fetch_access_token(
+            code=code,
+            code_verifier=proofs.get("code_verifier"),
+        )
+
+    def userinfo(self, token):
+        return self.oauth_client.userinfo(token=token)
+
+    def _decode_jwt(self, jwt):
+        if len(jwt.split("."))==5:
+            jwe = jose.JsonWebEncryption()
+            enc_key = self._get_key_by_use("enc")
+            result = jwe.deserialize_compact(jwt, enc_key)
+            jwt = result.get("payload").decode("utf-8")
+        jwks = self.oauth_client.fetch_jwk_set()
+        return jose.jwt.decode(jwt, jwks)
+
+    def _create_request_object(self, params):
+        extended_params = {
+            **params,
+            **{
+                "iss": self.config["client_id"],
+                "aud": self.config["iss"],
+                "exp": int((datetime.now() + timedelta(minutes=1)).timestamp()),
+                "iat": int(datetime.now().timestamp()),
+                "nbf": int(datetime.now().timestamp()),
+            },
+        }
+
+        extended_params = {
+            **params,
+            **{
+                "iss": self.config["client_id"],
+                "aud": self.config["iss"],
+                "exp": int((datetime.now() + timedelta(minutes=1)).timestamp()),
+                "iat": int(datetime.now().timestamp()),
+                "nbf": int(datetime.now().timestamp()),
+            },
+        }
+
+        sig_key = self._get_key_by_use("sig")
+        return jose.jwt.encode({"alg": sig_key["alg"]}, extended_params, sig_key).decode("utf-8")
+
+    def _get_key_by_use(self, use):
+        for key in self.config.get("jwks").keys:
+            if key["use"] == use:
+                return key
+
+    def _push_authorization_request(self, request_params):
+        par_endpoint = self.oauth_client.server_metadata.get(
+            "pushed_authorization_request_endpoint"
+        )
+        credentials = base64.b64encode(
+            f"{self.oauth_client.client_id}:{self.oauth_client.client_secret}".encode()
+        ).decode()
+        headers = {
+            "Authorization": f"Basic {credentials}",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+        }
+        response = requests.post(par_endpoint, data=request_params, headers=headers)
+        if response.status_code == 201:
+            return response.json()
+        else:
+            raise Exception(f"Failed to push authorization request: {response.text}")
+
+    def _extract_claims(self, claims_object):
+        if not isinstance(claims_object, dict):
+            return []
+
+        userinfo_keys = list(claims_object.get("userinfo", {}).keys())
+        id_token_keys = list(claims_object.get("id_token", {}).keys())
+
+        return list(set(userinfo_keys + id_token_keys))
+
+    def _init_client(self, iss):
+        self.oauth_client = self.oauth.register(
+            name="oauth_client",
+            client_id=self.config.get("client_id"),
+            client_secret=self.config.get("client_secret"),
+            redirect_uri="http://localhost:3001/button/oauth/callback",
+            server_metadata_url=f"{iss}/.well-known/openid-configuration",
+            client_kwargs={
+                "code_challenge_method": "S256",
+                "response_mode": "jwt",
+                "redirect_uri": self.config.get("redirect_uri"),
+            },
+        )
+        self.oauth_client.load_server_metadata()

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,26 @@ from setuptools import setup, find_packages
 
 setup(
     name='python_oidc_client',
-    version='0.0.1',
+    version='0.0.1',  # Update this version as per your package development
+    author='IDPartner',
+    author_email='engineering-external@idpartner.com',
+    description='A Python client for interacting with OpenID Connect providers.',
+    long_description="""The IDPartner gem offers a Python client for OpenID Connect providers, streamlining
+                        authorization, token acquisition, and user information retrieval. It supports various
+                        authentication methods and handles endpoint discovery via well-known configuration. The
+                        package simplifies JWT generation, signing, and verifying, making OpenID Connect integration
+                        straightforward and secure.""",
+    url='https://github.com/idpartner-app/python_oidc_client',
+    license='MIT',
     packages=find_packages(),
     install_requires=[
         'authlib',
         'requests',
     ],
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+    ],
+    python_requires='>=3.6',
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='python_oidc_client',
+    version='0.0.1',
+    packages=find_packages(),
+    install_requires=[
+        'authlib',
+        'requests',
+    ],
+)

--- a/test/test_idpartner.py
+++ b/test/test_idpartner.py
@@ -1,0 +1,353 @@
+import unittest
+import requests_mock
+from flask import Flask
+from authlib.integrations.flask_client import OAuth
+from idpartner import IDPartner
+import json
+from unittest.mock import Mock
+
+openid_configuration = {
+    "acr_values_supported": ["urn:mace:incommon:iap:silver"],
+    "authorization_endpoint": "http://localhost:9001/oidc/auth",
+    "claims_parameter_supported": True,
+    "claims_supported": [
+        "sub",
+        "vc.MockBankCredential",
+        "payment_details",
+        "payment_processing",
+        "address",
+        "email",
+        "birthdate",
+        "family_name",
+        "given_name",
+        "age_over_18",
+        "age_over_21",
+        "age_over_25",
+        "acr",
+        "sid",
+        "auth_time",
+        "iss",
+    ],
+    "code_challenge_methods_supported": ["S256"],
+    "end_session_endpoint": "http://localhost:9001/oidc/session/end",
+    "grant_types_supported": ["authorization_code", "refresh_token"],
+    "issuer": "http://localhost:9001/oidc",
+    "jwks_uri": "http://localhost:9001/oidc/jwks",
+    "registration_endpoint": "http://localhost:9001/oidc/reg",
+    "authorization_response_iss_parameter_supported": True,
+    "response_modes_supported": [
+        "form_post",
+        "fragment",
+        "query",
+        "jwt",
+        "query.jwt",
+        "fragment.jwt",
+        "form_post.jwt",
+    ],
+    "response_types_supported": ["code"],
+    "scopes_supported": [
+        "openid",
+        "offline_access",
+        "vc.MockBankCredential",
+        "payment_details",
+        "payment_processing",
+        "address",
+        "email",
+        "profile",
+        "age_over_18",
+        "age_over_21",
+        "age_over_25",
+    ],
+    "subject_types_supported": ["public"],
+    "token_endpoint_auth_methods_supported": [
+        "client_secret_basic",
+        "tls_client_auth",
+        "private_key_jwt",
+    ],
+    "token_endpoint_auth_signing_alg_values_supported": ["PS256"],
+    "token_endpoint": "http://localhost:9001/oidc/token",
+    "id_token_signing_alg_values_supported": ["PS256"],
+    "id_token_encryption_alg_values_supported": ["RSA-OAEP"],
+    "id_token_encryption_enc_values_supported": ["A256CBC-HS512"],
+    "pushed_authorization_request_endpoint": "http://localhost:9001/oidc/request",
+    "request_parameter_supported": True,
+    "request_uri_parameter_supported": False,
+    "request_object_signing_alg_values_supported": ["PS256"],
+    "request_object_encryption_alg_values_supported": [
+        "A128KW",
+        "A256KW",
+        "dir",
+        "RSA-OAEP",
+    ],
+    "request_object_encryption_enc_values_supported": [
+        "A128CBC-HS256",
+        "A128GCM",
+        "A256CBC-HS512",
+        "A256GCM",
+    ],
+    "userinfo_endpoint": "http://localhost:9001/oidc/me",
+    "payment_details_info_endpoint": "http://localhost:9001/oidc/payment_details",
+    "payment_processing_endpoint": "http://localhost:9001/oidc/payment_processing",
+    "authorization_signing_alg_values_supported": ["PS256"],
+    "authorization_encryption_alg_values_supported": ["RSA-OAEP"],
+    "authorization_encryption_enc_values_supported": ["A256CBC-HS512"],
+    "introspection_endpoint": "http://localhost:9001/oidc/token/introspection",
+    "revocation_endpoint": "http://localhost:9001/oidc/token/revocation",
+    "tls_client_certificate_bound_access_tokens": True,
+    "claim_types_supported": ["normal"],
+    "mtls_endpoint_aliases": {
+        "token_endpoint": "undefined/token",
+        "introspection_endpoint": "undefined/token/introspection",
+        "revocation_endpoint": "undefined/token/revocation",
+        "userinfo_endpoint": "undefined/me",
+        "pushed_authorization_request_endpoint": "undefined/request",
+        "payment_details_info_endpoint": "undefined/payment_details",
+        "payment_processing_endpoint": "undefined/payment_processing",
+    },
+}
+
+oidc_jwks = {
+    "keys": [
+        {
+            "kty": "RSA",
+            "use": "sig",
+            "kid": "-M_9vqJi0tSYDeXFh3clvZ70ntBosUVT9aqB--2SQiU",
+            "alg": "PS256",
+            "e": "AQAB",
+            "n": "xXGeqFK71mOGUdSSqWr2-DS2oCywcO5TLhLC7QFld-rx6LQ--qmqu7uQgiFO9aFl01MIZF_hs7D1RGX1EmB5odP98vqFVvpBvy3Sse6VZtMccKFtvywNsfWLGRwydzGw9B2s4yWy5ARP2w7fg1X3TnZgtOjtilwvJ1QCXWj3AshXcFj9Mn62z7iPnUcYZCupdyJObaCTcnclLBfUSk4AifkGvyqGplfDpfebLcJWMOUd4mm-Hv2qd9o95WhCfmsEALis8tgxkXTjAUIrS17Fw4-MIEDWFDDEn9bXQkzJ2vYGoKklN5k9_6y3pW95YIX81vvAEiLeRImWI-1q7ka5rw",
+        },
+        {
+            "kty": "RSA",
+            "use": "enc",
+            "kid": "sG0SskqyiA6IWm0Hb3VhmL8TUqSIx_Mqncb3CJNm63c",
+            "alg": "RSA-OAEP",
+            "e": "AQAB",
+            "n": "4LdgDCzIqIV0q2O42B8rXM7WulYJ3gQWJGpElWI4taXb71jPLhbuVphIggmqFmTejVkKGsOVieZoN8CHBkXQq7JmFXbDLHHzqY9uhIsJbNP6i-xRb-rnNPzNy7Vs5I0tpNByi30zQluyO8z0Q3LYK1gOvxAED3jAWfmpcIO1kjlGRxjWeql3Tt6uc3jbt3mqeTsqb7Y5jnO0ee7oHcncWiQvufcGTaOa7NusfTCAcTpWsxoTD3CbmRaVXW0VERpNkzXPpqls3Jned01oDI9F4LkCn03mD2srNUnMElf0AWT_fJ0ZlelBTmZQhV8Luxyoio9DjJDLKxf67CyrJ6VU3Q",
+        },
+    ]
+}
+
+
+class TestIDPartner(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.testing = True
+        self.oauth = OAuth(self.app)
+        self.config = {
+            "client_id": "test-client-id",
+            "client_secret": "test-client-secret",
+            "redirect_uri": "https://example.com/callback",
+            "account_selector_service_url": "https://auth-api.idpartner.com/oidc-proxy",
+        }
+        self.client = IDPartner(self.oauth, self.config)
+
+    def create_client_with_jwks(self):
+        config_with_jwks = self.config.copy()
+        config_with_jwks[
+            "jwks"
+        ] = '{"keys":[{"kty":"RSA","kid":"3eL_LSEgEHCNa45mwU7zZ83SEHvX2MesdKWcP14jQ8s","use":"sig","alg":"PS256","e":"AQAB","n":"0bml-h4oJEkmonIBzKZWKoaEt_jn5exY06RwOY-EB6Xp5RPbnQj8AdEW6tl8XBnpdJzhYMb7dnySzRj--jMxG_K8ZhTjLG68og4sm66H08QhWUey1lCN3vTvni8tCZtc7iPKgXJXTzyIkOse-UVkZwhQngPCh7MWjFcG4UfF97APl8XKcjpyshKakfYSpfbKoFqvRbqlJAKCyiwnVf3Ea-RXjh9spLsd77qTNMJEQt14PJxruYXTHPPubKvTJRqwR_ObxYrFxE5h8UZLFk8QYd6k_qKXdV0h2KNuu-PzmyIq7RmQMTr7M4xWexLzrQ7msnsPFJHncXfUD1-jQMtK5Q","d":"gDpoFuM1W-o16wCVxRC2gk24-9r9voChVtWloCv1Z8-zkFJx5jPGET5MKs9Kz-0v5hK9YjSHL0y_XRM5YrTGA_aH5kpDE7mpL9RGxfESLxIt6a6C07Jw668KiscBXGxXh2rut_K3G0VBool_aJ1a4_wbfmGCIQIIeUoEdN0zV1p84ZfCTpwDbbxfnK83ia6ke_RQmoKBjrUyiciUF6jiZEfb-1Vm7aE2NWU8yhmiZ14VAq0YR3xq0OlE8FxjWpr9Lr1i-5Gy-LDOnMRM4zfvYqC_FsiOQ-wGxAxMme_-tm3B05OIsk_O82YpyxpBZYgHn7AK7xahAQMMLiL2y2viyQ","p":"7UUoo8AKof_cIhRBSwmFhTt7_e8BZ7w0uPCAcSv4DNepCoUoTSNDHuuUmgPEULmQplHwhH-wW7ACVvylSZT4JYq-qwSVr9wJoFAYQDYiJizP73eVnFkfqiv2-xwPQaFONwGGxixuz0r8j16Tpe4iMK8Hy-LYpjucvTp6RrNHgls","q":"4kfZ2710YTnCXUsgga-lZxxDIloJ55iLtRSRizRGyxVCNkH1IMoo6pf59AiPkyk1iWYTx4IS_SkelSPWNtJLnFKmgocYikILsiVVSOoI1vkq9la3FTmJkRNzPfTtFWVf0_e0Ff7dkQxr3XBEZUVS0o9-y_V3k7sMsnfuajjva78","dp":"WFk_J7Izg1z1SA9IvLsf55tdsRFU8Z6H9zE-cmWP6KBJBmzMs-Rkctf_rlWmvPRL41Jxf7TYI1vnkyJiHYMF31zJYH7FigUh5HrOfOJrVtGq350krWIWQ1Q5lAk_uQ1qRVshJxuWa0OdxXjO-6MvQfd6rLWcPFHILEHhFABfqS8","dq":"GMe3kvnfadpSb7cPe0RJ_823iGaF2Sf6fL0g5za1Xf4Y_yof9xRMgMxd4hyh5ILJyx8zoVCcVb8QC1MeXWiQQTFH7NlwlYuADmVKPq7qguhMjSeX6yoe55VStIFDCWnNob_pp9L-XqkWkux9gP2jgU2XnCxoiPQeAtlhcZ6Eka8","qi":"Rh3yHepiLVy2gxHepFp2Yi9qSCULNCySjpDy9eeegEHQMIlH5cdO6Q5UmAtQZwoexWgXhmL8hPcgKumcGq0ZG_EpStIy176-McxtkmpbycY8Bfw6rk1FH2Sfn44oIB2JxUm8yHouh6UMz3e_WeisrmotbeAmH0NtG8DyPkTSgmA"},{"kty":"RSA","kid":"u64VsIB-cxX3NHf1nYn1OtBXmWWQfZZp2BVN1rZL6XU","use":"enc","alg":"RSA-OAEP","e":"AQAB","n":"0CIIQ8dAvOfVE38owR4I03lu1oHmCJz0vSKCRWVyNXSfXwl00eH6JmyDC8sFo2h66iU8vNBauYELoxNf4yT9hXsEcDgJcf9NPW186LSttqqgZ8wSycS7Pn3YTfbzH45R5mH_1zvsKnI8Xwi2DibpOht0bVWStG-EXkAkj6YQdSR1cMQXvtBIetWP6cPx7kG-qzjze3mvtIucnKRnphbW31Bker2Ykur3_ySqXJpCxUx3TchL5-pckTfS9Na6VALIBTLR8dHPq1GJXVgQOCh6GrY7ljIY7ZbkJW2_n1SgyNT49SuxBrPWKiIJW2uIdgMtq3Fp-BFMqJJGaqQ_W2jtAw","d":"x7A_ObhMNnI_jusrkM1eLneNjiUnLRBaB7S6RBam0v7HgYkzGcO0G3V07bWl_Tfa5hdABO_qe5yCK74E-4ub6ZszkO9SsJr_4nXPp_zhxiZCrBOx2v_znmtjQroyXQ5RKbbQnhKR7c-YeJ2E_mL61ZNNyzCVBqUP3NWxvljX5WqQiwsap-RN2ZiCXKrGiC_pG59uS5NSTNqf2cgXy0eSlQqt-7T6ZAZtsCz0I6pUYfHbXa3lIHCCRtTDWoVIoaKUa01FqyBeE04V6DvU9AOZWcK670cXbzhG1kkEk5HHYrQabPrBFXtRaOrApaasGDbZDv4fRW31WnNYLuhllPcQMQ","p":"55y41df36jmE0eQmLtI1jLAq7Adw-AhweUUL-Sklf4GkzCEnJ2wVguiCni8NrFMRiCrM95ntFwT6o1neuG4St3rK5wvE_SOYbLvw2MMnjqLVr4zbbDuLJ-w8-SeqDuFRxHkR6xp8J-YwXeD5N4blceEqU36XHpChcZkzoSWCO68","q":"5gxo1-MeuxMk_-RbS85hWMyQzVOBXGpuUlDpFELB2FxjAaaEN9bDRplWfVwTL-txN24NhFZepd8Bf7NL9nAGmGtTiEWhK5jQZz_WeXA6zRLwcm1v9Hbl516baMQy1cOa5VUyrGTsjVO3Q35j8fpRFa_RK-h3U6_bdDpO3UMyFO0","dp":"TEaZvJseYz3EFxeK15qU1htiV07wDk9BMz7g_ZJmbgJ1EmDMszfuMal-8rdOSnUk7fIihFxl71HNdSRwq85cTZ6b2dFPc4pYdV7Dp69FhLztoJ3D2XYWkvRC9E7yu2nK8uhoVUPopX8yaIhhqr67K3Da7ppfDErXUEEC9swSgrM","dq":"J_XP4HBbTjOtIaYRFcHrtvkRzhjLR7pVH4dedV6DPYoOyKKcJPbxRLouA-iSjKhhKje7sVkvZ7CtGfmTIGOlQaSjBfDSZjhNOyIjp0SPcj_v9HB-GgDtPpt4c2JhUjCAH4YFH10ImiQImXjC861_mDzKIM5oq-jIPhBC0rxxXqE","qi":"exJQqZEtA7p9XxItMAip-OTQ7W6n40xexi8PrJdfEvbrk0aAqO4-ixFyqlQnkwKGQt-IIBgwxjRPwEMMMufd_iLbc0EL1QZN370hSCyqIReGa5qH0W2vvoRf4QfmIiEWumfVWTOb9isCW1nlrPnCkBgGrLxTyZKS_BWwez7eDXQ","enc":"A256CBC-HS512"}]}'
+        return IDPartner(self.oauth, config_with_jwks)
+
+
+class WithRequestMocks(TestIDPartner):
+    def mock_oidc_configuration(self, mocker):
+        mocker.get(
+            "http://localhost:9001/oidc/.well-known/openid-configuration",
+            json=openid_configuration,
+        )
+
+    def mock_push_authorization_request(
+        self,
+        mocker,
+        request_uri="urn:ietf:params:oauth:request_uri:BfdJw4QAuMr5Ir6a-Uypx",
+    ):
+        mocker.post(
+            "http://localhost:9001/oidc/request",
+            json={"expires_in": 60, "request_uri": request_uri},
+            status_code=201,
+        )
+
+    def mock_oidc_jwks(self, mocker):
+        mocker.get(
+            "http://localhost:9001/oidc/jwks",
+            json=oidc_jwks,
+        )
+
+    def mock_token(self, mocker):
+        mocker.post(
+            "http://localhost:9001/oidc/token",
+            json={
+                "access_token": "NHtB5NG6woOQSeGn5BQr5qAu6ai8B_edu8S9VpfrAXY",
+                "expires_in": 60,
+                "id_token": "eyJhbGciOiJQUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ii1NXzl2cUppMHRTWURlWEZoM2Nsdlo3MG50Qm9zVVZUOWFxQi0tMlNRaVUifQ.eyJzdWIiOiIzMmYwOTk4ZmM3MTBjNjhjNzY2MWY3M2QxMmJmMDdlOTg3YTRjYjY4OGIzZGZhNDhhNmVlMjdmOTUyNjJlZTIyIiwiZW1haWwiOiJQaGlsaXBITG92ZXR0QG1pa29tb3Rlc3QuY29tIiwiZmFtaWx5X25hbWUiOiJMb3ZldHQiLCJnaXZlbl9uYW1lIjoiUGhpbGlwIiwibm9uY2UiOiJMYk1SNTBJRXVCQmtOWmpPZFhtcURkV2FXWmVXUUg0emtxblBpV1FjNGR1U2FBV2JlZnB3VE9hLXh4eDYxVEljTXJZcWdzNWhrUVJDN0d5MFB0LVN4USIsImF0X2hhc2giOiJibkFTcEN2M2xNLTZ2dzBHZWd0YW1nIiwiYXVkIjoiRjhXOFpLVWl5UlhfMG5vT0xhOTQzIiwiZXhwIjoxNjk4ODc0MDU5LCJpYXQiOjE2OTg4NzM5OTksImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTAwMS9vaWRjIn0.QLySATBZIUYbJ7fNKCsTNypuF34H4TBjNywy-FB2O-QF0NXrSNIhIwGfJ7K_VHQfYXodkqNxUc-rOmNxU053IaEtlV-tTFhrxEshiD5P5UpMtecBhESac_yG621OS-zH-_NrZLhXELdBLEojAISYODdNh3DXv1ivaoWRHQFBALmWotc7MnIFPUdior1-IocKyn-k6b80KEOx5qTfvXIrmELrlWqsFzJA8DNpKqGPcyBzDjLs26zCbS-jRgvg1jk2I6YT9ywYWitqm5XuzQze-e3A1h9_r1U3eTG2BL4jA9l0X6qNOu602MOCP0aTTLALV74mAkcrQB3_lCWpHnOntQ",
+                "scope": "openid offline_access email profile birthdate address",
+                "token_type": "Bearer",
+            },
+        )
+
+    def mock_user_info(self, mocker):
+        mocker.get(
+            "http://localhost:9001/oidc/me",
+            json={
+                "sub": "32f0998fc710c68c7661f73d12bf07e987a4cb688b3dfa48a6ee27f95262ee22",
+                "email": "PhilipHLovett@mikomotest.com",
+                "family_name": "Lovett",
+                "given_name": "Philip",
+            },
+        )
+
+
+class TestInitialization(TestIDPartner):
+    def test_initializes_with_config(self):
+        self.assertIsInstance(self.client, IDPartner)
+
+    def test_raises_error_if_oauth_missing(self):
+        with self.assertRaises(ValueError):
+            IDPartner(None, self.config)
+
+    def test_raises_error_if_config_missing(self):
+        with self.assertRaises(ValueError):
+            IDPartner(Mock(), None)
+
+    def test_raises_error_for_unsupported_auth_method(self):
+        config = self.config.copy()
+        config["token_endpoint_auth_method"] = "unsupported_method"
+        with self.assertRaises(ValueError):
+            IDPartner(Mock(), config)
+
+    def test_default_token_endpoint_auth_method(self):
+        client = IDPartner(Mock(), self.config)
+        self.assertEqual(
+            client.config.get("token_endpoint_auth_method"), "client_secret_basic"
+        )
+
+
+class TestGenerateProofs(TestIDPartner):
+    def test_generate_proofs(self):
+        proofs = self.client.generate_proofs()
+        self.assertIn("state", proofs)
+        self.assertIn("nonce", proofs)
+        self.assertIn("code_verifier", proofs)
+
+
+class TestGetAuthorizationUrl(WithRequestMocks):
+    def test_returns_authorization_url_pointing_to_account_selector(self):
+        proofs = self.client.generate_proofs()
+        scope = "openid offline_access email profile birthdate address"
+        url = self.client.get_authorization_url({}, proofs, scope, {})
+        self.assertEqual(
+            url,
+            "https://auth-api.idpartner.com/oidc-proxy/auth/select-accounts?client_id=test-client-id&visitor_id=None&scope=openid offline_access email profile birthdate address&claims=",
+        )
+
+    def test_returns_authorization_url_pointing_to_iss(self):
+        with requests_mock.Mocker() as m:
+            self.mock_oidc_configuration(m)
+            self.mock_push_authorization_request(m)
+
+            proofs = self.client.generate_proofs()
+            scope = "openid offline_access email profile birthdate address"
+            url = self.client.get_authorization_url(
+                {"iss": "http://localhost:9001/oidc"}, proofs, scope, {}
+            )
+            self.assertEqual(
+                url,
+                "http://localhost:9001/oidc/auth?request_uri=urn:ietf:params:oauth:request_uri:BfdJw4QAuMr5Ir6a-Uypx",
+            )
+
+    def test_returns_authorization_url_pointing_to_iss_using_jwks(self):
+        with requests_mock.Mocker() as m:
+            self.mock_oidc_configuration(m)
+            self.mock_push_authorization_request(m)
+
+            client_with_jwks = self.create_client_with_jwks()
+            proofs = client_with_jwks.generate_proofs()
+            scope = "openid offline_access email profile birthdate address"
+            url = client_with_jwks.get_authorization_url(
+                {"iss": "http://localhost:9001/oidc"}, proofs, scope, {}
+            )
+            self.assertEqual(
+                url,
+                "http://localhost:9001/oidc/auth?request_uri=urn:ietf:params:oauth:request_uri:BfdJw4QAuMr5Ir6a-Uypx",
+            )
+
+            post_request = next(
+                (req for req in m.request_history if req.method == "POST"), None
+            )
+            body = post_request.text.split("=")
+            param_name = body[0]
+            param_value = body[1]
+            self.assertEqual(param_name, "request")
+            self.assertEqual(len(param_value.split(".")), 3)
+
+
+class TestToken(WithRequestMocks):
+    def test_exchange_code_from_jws_for_token(self):
+        with requests_mock.Mocker() as m:
+            self.mock_oidc_configuration(m)
+            self.mock_push_authorization_request(m)
+            self.mock_oidc_jwks(m)
+            self.mock_token(m)
+
+            proofs = self.client.generate_proofs()
+            scope = "openid offline_access email profile birthdate address"
+            url = self.client.get_authorization_url(
+                {"iss": "http://localhost:9001/oidc"}, proofs, scope, {}
+            )
+            jws_token = "eyJhbGciOiJQUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ii1NXzl2cUppMHRTWURlWEZoM2Nsdlo3MG50Qm9zVVZUOWFxQi0tMlNRaVUifQ.eyJjb2RlIjoiVEJvYTlLR1lsU2RPMGZGdnhJMklYV2NnV3diT1VVYlpQNjB6VWh5TkQyVyIsInN0YXRlIjoib3FKYm13eDZuQ1ZDRF9LanQ2cE9kbjZpZTF4R3REY2VlTHRiN0x4azRBYzBIeWxEMzBxd241cGdyYm9rRjBmQW53aVBOT1JPQWk4ZWtGYlhXbHJIU3ciLCJhdWQiOiJGOFc4WktVaXlSWF8wbm9PTGE5NDMiLCJleHAiOjE2OTg4Njc3NDYsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTAwMS9vaWRjIn0.XACQeu39-bNTLSW0AKh5IvNnjzQhCsTejvPpYEt-Obcyu6D-Z6hm7r-9q_TM5eRL9S2M2D9TqzOMro_ncZ7GUR4ERUn1sCmHxBE_amSUeecXIifTYonUPnRf3AfzJ3hDyewXQ2nyJt2wVmFe2WXPkJsbFZadZnjJt9hu5TG7QH2wPraZj7JcfERF6kbmu30NzPC-qW8DmzH3B5KpJ74S3WkUSgq0C3S_BHDbzYKjuAnKtrxt92jFlvthYApaLrimNKxjvZCe38Yd8G0kq8EWVi3X4pX2GF9cGc7mheZB88gN_AEWiSgPuUMKOWpEDMu_TDAetZix8sBtUnDFnz7vcg"
+            proofs = {"code_verifier": "test_code_verifier"}
+            token_response = self.client.token({"response": jws_token}, proofs)
+            self.assertIn("access_token", token_response)
+
+    def test_exchange_code_from_jwe_for_token(self):
+        with requests_mock.Mocker() as m:
+            self.mock_oidc_configuration(m)
+            self.mock_push_authorization_request(m)
+            self.mock_oidc_jwks(m)
+            self.mock_token(m)
+
+            proofs = self.client.generate_proofs()
+            scope = "openid offline_access email profile birthdate address"
+            url = self.client.get_authorization_url(
+                {"iss": "http://localhost:9001/oidc"}, proofs, scope, {}
+            )
+            jws_token = "eyJhbGciOiJQUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ii1NXzl2cUppMHRTWURlWEZoM2Nsdlo3MG50Qm9zVVZUOWFxQi0tMlNRaVUifQ.eyJjb2RlIjoiVEJvYTlLR1lsU2RPMGZGdnhJMklYV2NnV3diT1VVYlpQNjB6VWh5TkQyVyIsInN0YXRlIjoib3FKYm13eDZuQ1ZDRF9LanQ2cE9kbjZpZTF4R3REY2VlTHRiN0x4azRBYzBIeWxEMzBxd241cGdyYm9rRjBmQW53aVBOT1JPQWk4ZWtGYlhXbHJIU3ciLCJhdWQiOiJGOFc4WktVaXlSWF8wbm9PTGE5NDMiLCJleHAiOjE2OTg4Njc3NDYsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTAwMS9vaWRjIn0.XACQeu39-bNTLSW0AKh5IvNnjzQhCsTejvPpYEt-Obcyu6D-Z6hm7r-9q_TM5eRL9S2M2D9TqzOMro_ncZ7GUR4ERUn1sCmHxBE_amSUeecXIifTYonUPnRf3AfzJ3hDyewXQ2nyJt2wVmFe2WXPkJsbFZadZnjJt9hu5TG7QH2wPraZj7JcfERF6kbmu30NzPC-qW8DmzH3B5KpJ74S3WkUSgq0C3S_BHDbzYKjuAnKtrxt92jFlvthYApaLrimNKxjvZCe38Yd8G0kq8EWVi3X4pX2GF9cGc7mheZB88gN_AEWiSgPuUMKOWpEDMu_TDAetZix8sBtUnDFnz7vcg"
+            proofs = {"code_verifier": "test_code_verifier"}
+            token_response = self.client.token({"response": jws_token}, proofs)
+            self.assertIn("access_token", token_response)
+
+
+class TestGetUserInfo(WithRequestMocks):
+    def test_retrieve_user_info(self):
+        with requests_mock.Mocker() as m:
+            self.mock_oidc_configuration(m)
+            self.mock_push_authorization_request(m)
+            self.mock_oidc_jwks(m)
+            self.mock_token(m)
+            self.mock_user_info(m)
+
+            proofs = self.client.generate_proofs()
+            scope = "openid offline_access email profile birthdate address"
+            url = self.client.get_authorization_url(
+                {"iss": "http://localhost:9001/oidc"}, proofs, scope, {}
+            )
+            jws_token = "eyJhbGciOiJQUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ii1NXzl2cUppMHRTWURlWEZoM2Nsdlo3MG50Qm9zVVZUOWFxQi0tMlNRaVUifQ.eyJjb2RlIjoiVEJvYTlLR1lsU2RPMGZGdnhJMklYV2NnV3diT1VVYlpQNjB6VWh5TkQyVyIsInN0YXRlIjoib3FKYm13eDZuQ1ZDRF9LanQ2cE9kbjZpZTF4R3REY2VlTHRiN0x4azRBYzBIeWxEMzBxd241cGdyYm9rRjBmQW53aVBOT1JPQWk4ZWtGYlhXbHJIU3ciLCJhdWQiOiJGOFc4WktVaXlSWF8wbm9PTGE5NDMiLCJleHAiOjE2OTg4Njc3NDYsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTAwMS9vaWRjIn0.XACQeu39-bNTLSW0AKh5IvNnjzQhCsTejvPpYEt-Obcyu6D-Z6hm7r-9q_TM5eRL9S2M2D9TqzOMro_ncZ7GUR4ERUn1sCmHxBE_amSUeecXIifTYonUPnRf3AfzJ3hDyewXQ2nyJt2wVmFe2WXPkJsbFZadZnjJt9hu5TG7QH2wPraZj7JcfERF6kbmu30NzPC-qW8DmzH3B5KpJ74S3WkUSgq0C3S_BHDbzYKjuAnKtrxt92jFlvthYApaLrimNKxjvZCe38Yd8G0kq8EWVi3X4pX2GF9cGc7mheZB88gN_AEWiSgPuUMKOWpEDMu_TDAetZix8sBtUnDFnz7vcg"
+            proofs = {"code_verifier": "test_code_verifier"}
+            token_response = self.client.token({"response": jws_token}, proofs)
+            user_info = self.client.userinfo(token_response)
+            self.assertEqual(user_info.get('sub'), "32f0998fc710c68c7661f73d12bf07e987a4cb688b3dfa48a6ee27f95262ee22")
+            self.assertEqual(user_info.get('email'), "PhilipHLovett@mikomotest.com")
+            self.assertEqual(user_info.get('family_name'), "Lovett")
+            self.assertEqual(user_info.get('given_name'), "Philip")
+
+class TestGetPublicJwks(TestIDPartner):
+    def test_returns_public_jwks(self):
+        client_with_jwks = self.create_client_with_jwks()
+        public_jwks = client_with_jwks.jwks()
+        self.assertIsInstance(public_jwks, dict)
+        for key in public_jwks.get("keys", []):
+            self.assertNotIn("d", key)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR introduces the creation of the python_oidc_client which serves as a Python client for interacting with OpenID Connect providers using the IDPartner class. The gem simplifies the process of authorization, token acquisition, and user information retrieval from OIDC providers by encapsulating the complexities of generating, signing, and verifying JWTs. An example usage of the gem has been provided in the examples folder for reference.

https://identity-online.atlassian.net/browse/DEV-1317